### PR TITLE
Fix profile and listing image uploads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ulsan-campus-plus",
       "version": "0.1.0",
       "dependencies": {
+        "@ai-sdk/google": "^3.0.64",
         "@ai-sdk/openai": "^3.0.52",
         "@ai-sdk/react": "^3.0.160",
         "@tailwindcss/typography": "^0.5.19",
@@ -54,6 +55,22 @@
         "@ai-sdk/provider": "3.0.8",
         "@ai-sdk/provider-utils": "4.0.23",
         "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/google": {
+      "version": "3.0.64",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.64.tgz",
+      "integrity": "sha512-CbR82EgGPNrj/6q0HtclwuCqe0/pDShyv3nWDP/A9DroujzWXnLMlUJVrgPOsg4b40zQCwwVs2XSKCxvt/4QaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@ai-sdk/google": "^3.0.64",
     "@ai-sdk/openai": "^3.0.52",
     "@ai-sdk/react": "^3.0.160",
     "@tailwindcss/typography": "^0.5.19",

--- a/src/app/api/ai/chat/route.ts
+++ b/src/app/api/ai/chat/route.ts
@@ -1,4 +1,5 @@
 import { convertToModelMessages, streamText, type UIMessage } from 'ai';
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { openai } from '@ai-sdk/openai';
 import { NextResponse } from 'next/server';
 import connectDB from '@/lib/mongoose';
@@ -32,6 +33,35 @@ const welcomeMessage: UIMessage = {
   ],
 };
 
+function getAIErrorMessage(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+
+  if (message.includes('insufficient_quota') || message.toLowerCase().includes('quota')) {
+    return 'The AI assistant is connected, but the configured AI provider has no available quota. Please check billing, usage limits, or use a key from a project with available credits.';
+  }
+
+  if (message.toLowerCase().includes('api key')) {
+    return 'The AI assistant could not authenticate with the configured AI provider. Please check GEMINI_API_KEY or OPENAI_API_KEY in .env.local.';
+  }
+
+  return 'The AI assistant could not complete the response. Please try again in a moment.';
+}
+
+function getConfiguredModel() {
+  const geminiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY || process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+
+  if (geminiKey) {
+    const google = createGoogleGenerativeAI({ apiKey: geminiKey });
+    return google('gemini-2.5-flash');
+  }
+
+  if (process.env.OPENAI_API_KEY) {
+    return openai('gpt-4o');
+  }
+
+  return null;
+}
+
 export async function GET(req: Request) {
   try {
     const { searchParams } = new URL(req.url);
@@ -55,9 +85,11 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    if (!process.env.OPENAI_API_KEY) {
+    const model = getConfiguredModel();
+
+    if (!model) {
       return NextResponse.json(
-        { error: 'OPENAI_API_KEY is not configured on the server' },
+        { error: 'No AI provider key is configured. Add GEMINI_API_KEY or OPENAI_API_KEY in .env.local.' },
         { status: 503 }
       );
     }
@@ -71,13 +103,14 @@ export async function POST(req: Request) {
     }
 
     const result = streamText({
-      model: openai('gpt-4o'),
+      model,
       system: 'You are ULSAN Campus+, a practical AI assistant for Ulsan University students. Be concise, helpful, and student-friendly. Help with computer science, study planning, schedules, notes, marketplace posts, and campus questions. Use Markdown when it improves readability.',
       messages: await convertToModelMessages(messages),
     });
 
     return result.toUIMessageStreamResponse({
       originalMessages: messages,
+      onError: getAIErrorMessage,
       onFinish: async ({ messages: finishedMessages }) => {
         if (userId && userId !== 'anonymous') {
           try {

--- a/src/app/api/auth/profile/route.ts
+++ b/src/app/api/auth/profile/route.ts
@@ -1,28 +1,38 @@
 import { NextResponse } from 'next/server';
 import connectDB from '@/lib/mongoose';
 import User from '@/models/User';
-import * as jose from 'jose';
+import jwt from 'jsonwebtoken';
+
+function getUserId(req: Request) {
+  const token = req.headers.get('authorization')?.split(' ')[1];
+  if (!token) return null;
+
+  try {
+    const payload = jwt.verify(
+      token,
+      process.env.JWT_ACCESS_SECRET || 'fallback_access_secret'
+    ) as jwt.JwtPayload & { userId?: string; id?: string };
+
+    return payload.userId || payload.id || null;
+  } catch {
+    return null;
+  }
+}
 
 export async function PUT(req: Request) {
   try {
-    const authHeader = req.headers.get('authorization');
-    const token = authHeader?.split(' ')[1];
-
-    if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
-    const secret = new TextEncoder().encode(process.env.JWT_ACCESS_SECRET || 'fallback_access_secret');
-    const { payload } = await jose.jwtVerify(token, secret);
-    
-    if (!payload || !payload.id) {
-       return NextResponse.json({ error: 'Invalid Token' }, { status: 401 });
-    }
+    const userId = getUserId(req);
+    if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const { profilePicture } = await req.json();
+    if (typeof profilePicture !== 'string') {
+      return NextResponse.json({ error: 'Profile picture URL is required' }, { status: 400 });
+    }
 
     await connectDB();
     const updatedUser = await User.findByIdAndUpdate(
-       payload.id,
-       { $set: { profilePicture } },
+       userId,
+       { $set: { profilePicture: profilePicture.trim() } },
        { new: true }
     ).select('-password');
 

--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -42,7 +42,7 @@ export async function POST(req: Request) {
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'strict',
       maxAge: 7 * 24 * 60 * 60,
-      path: '/api/auth/refresh',
+      path: '/',
     });
 
     return NextResponse.json({ accessToken: tokens.accessToken });

--- a/src/app/api/friends/route.ts
+++ b/src/app/api/friends/route.ts
@@ -7,7 +7,7 @@ import jwt from 'jsonwebtoken';
 function getUserId(req: Request) {
   const token = req.headers.get('authorization')?.split(' ')[1];
   if(!token) return null;
-  try { return (jwt.verify(token, process.env.JWT_ACCESS_SECRET!) as any).userId; } catch(e) { return null; }
+  try { return (jwt.verify(token, process.env.JWT_ACCESS_SECRET!) as jwt.JwtPayload).userId; } catch { return null; }
 }
 
 export async function GET(req: Request) {
@@ -23,16 +23,16 @@ export async function GET(req: Request) {
     const users = await User.find({ 
       name: { $regex: query, $options: 'i' },
       _id: { $ne: userId }
-    }, 'name department studentId').limit(20);
+    }, 'name department studentId profilePicture').limit(20);
     return NextResponse.json(users);
   }
 
   // Aggregate pending requests AND accepted active connections mapping logic
-  const pending = await Friendship.find({ recipient: userId, status: 'pending' }).populate('requester', 'name department');
+  const pending = await Friendship.find({ recipient: userId, status: 'pending' }).populate('requester', 'name department profilePicture');
   const connections = await Friendship.find({
     $or: [{ requester: userId }, { recipient: userId }],
     status: 'accepted'
-  }).populate('requester', 'name department').populate('recipient', 'name department');
+  }).populate('requester', 'name department profilePicture').populate('recipient', 'name department profilePicture');
 
   return NextResponse.json({ pending, connections });
 }

--- a/src/app/api/lost-found/route.ts
+++ b/src/app/api/lost-found/route.ts
@@ -18,7 +18,7 @@ export async function GET(req: Request) {
   
   const query = filterType ? { type: filterType, status: 'active' } : { status: 'active' };
   
-  const items = await LostItem.find(query).populate('reportedBy', 'name email department').sort({ createdAt: -1 });
+  const items = await LostItem.find(query).populate('reportedBy', 'name email department profilePicture').sort({ createdAt: -1 });
   return NextResponse.json(items);
 }
 

--- a/src/app/api/market/route.ts
+++ b/src/app/api/market/route.ts
@@ -7,24 +7,44 @@ function getUserId(req: Request) {
   const token = req.headers.get('authorization')?.split(' ')[1];
   if (!token) return null;
   try {
-    return (jwt.verify(token, process.env.JWT_ACCESS_SECRET!) as { userId: string }).userId;
-  } catch(e) { return null; }
+    const payload = jwt.verify(token, process.env.JWT_ACCESS_SECRET || 'fallback_access_secret') as { userId?: string; id?: string };
+    return payload.userId || payload.id || null;
+  } catch { return null; }
 }
 
 export async function GET(req: Request) {
-  await connectDB();
-  const items = await MarketItem.find({ status: 'available' }).populate('sellerId', 'name email department profilePicture').sort({ createdAt: -1 });
-  return NextResponse.json(items);
+  try {
+    await connectDB();
+    const items = await MarketItem.find({ status: 'available' }).populate('sellerId', 'name email department profilePicture').sort({ createdAt: -1 });
+    return NextResponse.json(items);
+  } catch {
+    return NextResponse.json({ error: 'Failed to load marketplace listings' }, { status: 500 });
+  }
 }
 
 export async function POST(req: Request) {
   const userId = getUserId(req);
-  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  
-  const body = await req.json();
-  await connectDB();
-  const item = await MarketItem.create({ ...body, sellerId: userId });
-  return NextResponse.json(item);
+  if (!userId) return NextResponse.json({ error: 'Your session expired. Please sign in again.' }, { status: 401 });
+
+  try {
+    const body = await req.json();
+    const title = typeof body.title === 'string' ? body.title.trim() : '';
+    const description = typeof body.description === 'string' ? body.description.trim() : '';
+    const price = Number(body.price);
+    const imageUrls = Array.isArray(body.imageUrls)
+      ? body.imageUrls.filter((url: unknown) => typeof url === 'string' && url.trim()).map((url: string) => url.trim())
+      : [];
+
+    if (!title || !description || Number.isNaN(price) || price < 0) {
+      return NextResponse.json({ error: 'Please enter a title, description, and valid price.' }, { status: 400 });
+    }
+
+    await connectDB();
+    const item = await MarketItem.create({ title, description, price, imageUrls, sellerId: userId });
+    return NextResponse.json(item);
+  } catch {
+    return NextResponse.json({ error: 'Failed to publish listing. Please try again.' }, { status: 500 });
+  }
 }
 
 export async function DELETE(req: Request) {

--- a/src/app/api/market/route.ts
+++ b/src/app/api/market/route.ts
@@ -13,7 +13,7 @@ function getUserId(req: Request) {
 
 export async function GET(req: Request) {
   await connectDB();
-  const items = await MarketItem.find({ status: 'available' }).populate('sellerId', 'name email department').sort({ createdAt: -1 });
+  const items = await MarketItem.find({ status: 'available' }).populate('sellerId', 'name email department profilePicture').sort({ createdAt: -1 });
   return NextResponse.json(items);
 }
 

--- a/src/app/dashboard/chat/page.tsx
+++ b/src/app/dashboard/chat/page.tsx
@@ -5,6 +5,7 @@ import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { MessageCircle, Send } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
+import { Avatar } from '@/components/ui/Avatar';
 
 export default function ChatPage() {
   const [friends, setFriends] = useState<any[]>([]);
@@ -76,7 +77,7 @@ export default function ChatPage() {
                    onClick={() => setActiveChat(peer)}
                    className={`p-3 rounded-xl cursor-pointer transition-all flex items-center gap-3 ${isActive ? 'bg-brand-purple/20 border border-brand-purple/50' : 'hover:bg-white/5 border border-transparent'}`}
                  >
-                   <div className={`w-10 h-10 rounded-full flex items-center justify-center text-white font-bold shrink-0 ${isActive ? 'gradient-bg shadow-brand-indigo/50' : 'bg-white/10'}`}>{peer.name.charAt(0)}</div>
+                   <Avatar src={peer.profilePicture} name={peer.name} className={`h-10 w-10 text-sm ${isActive ? 'shadow-brand-indigo/50' : ''}`} />
                    <div className="truncate">
                      <p className={`font-bold text-sm leading-tight truncate ${isActive ? 'text-white' : 'text-gray-300'}`}>{peer.name}</p>
                      <p className="text-[10px] text-gray-500 uppercase tracking-widest truncate">{peer.department}</p>
@@ -92,9 +93,7 @@ export default function ChatPage() {
             <>
               <div className="px-6 py-4 border-b border-white/5 bg-white/5 flex items-center justify-between z-10 shrink-0">
                  <div className="flex items-center gap-4">
-                    <div className="w-12 h-12 rounded-full gradient-bg flex items-center justify-center text-white font-bold text-xl uppercase shadow-[0_0_15px_rgba(102,126,234,0.3)]">
-                       {activeChat.name.charAt(0)}
-                    </div>
+                    <Avatar src={activeChat.profilePicture} name={activeChat.name} className="h-12 w-12 text-xl shadow-[0_0_15px_rgba(102,126,234,0.3)]" />
                     <div>
                        <h3 className="text-xl font-bold text-white leading-tight">{activeChat.name}</h3>
                        <span className="text-[10px] text-brand-accent tracking-widest uppercase flex items-center gap-1">

--- a/src/app/dashboard/lost-found/page.tsx
+++ b/src/app/dashboard/lost-found/page.tsx
@@ -7,6 +7,23 @@ import { Button } from '@/components/ui/Button';
 import { MapPin, UploadCloud, Target } from 'lucide-react';
 import { motion } from 'framer-motion';
 import toast from 'react-hot-toast';
+import { Avatar } from '@/components/ui/Avatar';
+
+function SelectedPhotoPreview({ file }: { file: File }) {
+  const [src, setSrc] = useState('');
+
+  useEffect(() => {
+    const nextSrc = URL.createObjectURL(file);
+    setSrc(nextSrc);
+    return () => URL.revokeObjectURL(nextSrc);
+  }, [file]);
+
+  return (
+    <div className="aspect-square overflow-hidden rounded-lg border border-white/10 bg-black/40">
+      {src && <img src={src} alt={file.name} className="h-full w-full object-cover" />}
+    </div>
+  );
+}
 
 export default function LostFoundPage() {
   const [items, setItems] = useState<any[]>([]);
@@ -38,7 +55,13 @@ export default function LostFoundPage() {
         const formData = new FormData();
         formData.append('file', file);
         const uploadRes = await fetch('/api/upload', { method: 'POST', body: formData });
-        if(uploadRes.ok) imageUrls.push((await uploadRes.json()).url);
+        if (!uploadRes.ok) {
+          const error = await uploadRes.json().catch(() => ({ error: 'Image upload failed' }));
+          throw new Error(error.error || 'Image upload failed');
+        }
+        const uploaded = await uploadRes.json();
+        if (!uploaded.url) throw new Error('Image upload did not return a URL');
+        imageUrls.push(uploaded.url);
       }
 
       const res = await fetch('/api/lost-found', {
@@ -51,7 +74,9 @@ export default function LostFoundPage() {
          setTitle(''); setDescription(''); setLocation(''); setFiles([]);
          fetchItems();
       }
-    } catch(e) { toast.error("Failed to submit."); } finally { setIsPosting(false); }
+    } catch(e) {
+      toast.error(e instanceof Error ? e.message : "Failed to submit.");
+    } finally { setIsPosting(false); }
   };
 
   return (
@@ -95,6 +120,13 @@ export default function LostFoundPage() {
                   <UploadCloud size={24} className="mb-2" />
                   {files.length > 0 ? <span className="font-bold text-emerald-400">{files.length} Photo(s) Selected</span> : "Upload Photos"}
                </label>
+               {files.length > 0 && (
+                  <div className="mt-3 grid grid-cols-3 gap-3 sm:grid-cols-5">
+                     {files.map((file) => (
+                        <SelectedPhotoPreview key={`${file.name}-${file.lastModified}`} file={file} />
+                     ))}
+                  </div>
+               )}
             </div>
             <Button type="submit" isLoading={isPosting} className="bg-emerald-500 text-black shadow-emerald-500/30 hover:shadow-emerald-500/50 hover:bg-emerald-400 font-bold">Submit Post</Button>
          </form>
@@ -124,8 +156,11 @@ export default function LostFoundPage() {
                      
                      <div className="mt-auto pt-4 border-t border-white/5 flex flex-col gap-2">
                         <span className="text-[10px] text-gray-500 font-mono flex items-center gap-2 tracking-widest"><MapPin size={10} className={item.type === 'lost' ? 'text-red-400' : 'text-blue-400'}/> LOCATION: {item.locationFound}</span>
-                        <div className="flex items-center justify-between mt-1">
-                           <span className="text-[10px] text-brand-accent uppercase font-bold tracking-widest truncate">{item.reportedBy?.name}</span>
+                        <div className="flex items-center justify-between gap-3 mt-1">
+                           <div className="flex min-w-0 items-center gap-2">
+                              <Avatar src={item.reportedBy?.profilePicture} name={item.reportedBy?.name} className="h-8 w-8 text-xs" />
+                              <span className="text-[10px] text-brand-accent uppercase font-bold tracking-widest truncate">{item.reportedBy?.name}</span>
+                           </div>
                            <Button variant="ghost" className="text-white hover:bg-emerald-500/20 border border-emerald-500/30 text-[10px] uppercase font-bold tracking-widest h-7 px-3">Message</Button>
                         </div>
                      </div>

--- a/src/app/dashboard/market/page.tsx
+++ b/src/app/dashboard/market/page.tsx
@@ -7,6 +7,23 @@ import { Button } from '@/components/ui/Button';
 import { ShoppingBag, UploadCloud, Tag, Trash, Edit2, X } from 'lucide-react';
 import { motion } from 'framer-motion';
 import toast from 'react-hot-toast';
+import { Avatar } from '@/components/ui/Avatar';
+
+function SelectedPhotoPreview({ file }: { file: File }) {
+  const [src, setSrc] = useState('');
+
+  useEffect(() => {
+    const nextSrc = URL.createObjectURL(file);
+    setSrc(nextSrc);
+    return () => URL.revokeObjectURL(nextSrc);
+  }, [file]);
+
+  return (
+    <div className="aspect-square overflow-hidden rounded-lg border border-white/10 bg-black/40">
+      {src && <img src={src} alt={file.name} className="h-full w-full object-cover" />}
+    </div>
+  );
+}
 
 export default function MarketPage() {
   const [items, setItems] = useState<any[]>([]);
@@ -72,7 +89,13 @@ export default function MarketPage() {
         const formData = new FormData();
         formData.append('file', file);
         const uploadRes = await fetch('/api/upload', { method: 'POST', body: formData });
-        if(uploadRes.ok) imageUrls.push((await uploadRes.json()).url);
+        if (!uploadRes.ok) {
+          const error = await uploadRes.json().catch(() => ({ error: 'Image upload failed' }));
+          throw new Error(error.error || 'Image upload failed');
+        }
+        const uploaded = await uploadRes.json();
+        if (!uploaded.url) throw new Error('Image upload did not return a URL');
+        imageUrls.push(uploaded.url);
       }
 
       const method = editingId ? 'PUT' : 'POST';
@@ -90,7 +113,9 @@ export default function MarketPage() {
          cancelEdit();
          fetchItems();
       } else toast.error("Processing failed.");
-    } catch(e) { toast.error("Network error."); } finally { setIsPosting(false); }
+    } catch(e) {
+      toast.error(e instanceof Error ? e.message : "Network error.");
+    } finally { setIsPosting(false); }
   };
 
   return (
@@ -138,6 +163,13 @@ export default function MarketPage() {
                     <UploadCloud size={24} className="mb-2" />
                     {files.length > 0 ? <span className="text-brand-purple font-bold">{files.length} Photo(s) Selected</span> : "Upload Pictures"}
                  </label>
+                 {files.length > 0 && (
+                   <div className="mt-3 grid grid-cols-3 gap-3 sm:grid-cols-5">
+                     {files.map((file) => (
+                       <SelectedPhotoPreview key={`${file.name}-${file.lastModified}`} file={file} />
+                     ))}
+                   </div>
+                 )}
               </div>
             )}
             <Button type="submit" isLoading={isPosting} className="bg-brand-purple font-bold text-white shadow-brand-purple/30 hover:shadow-[0_0_20px_rgba(167,139,250,0.5)]">
@@ -178,12 +210,15 @@ export default function MarketPage() {
                        <h4 className="font-bold text-xl text-white leading-tight mb-2 truncate">{item.title}</h4>
                        <p className="text-gray-400 text-xs mb-4 line-clamp-2 leading-relaxed">{item.description}</p>
                        
-                       <div className="mt-auto pt-4 border-t border-white/10 flex items-center justify-between">
-                          <div>
+                       <div className="mt-auto pt-4 border-t border-white/10 flex items-center justify-between gap-3">
+                          <div className="flex min-w-0 items-center gap-3">
+                             <Avatar src={item.sellerId?.profilePicture} name={isOwner ? 'You' : item.sellerId?.name} className="h-10 w-10 text-sm" />
+                             <div className="min-w-0">
                              <p className={`text-xs font-bold tracking-tight ${isOwner ? 'text-brand-purple' : 'text-brand-accent'}`}>
                                 {isOwner ? 'You (Owner)' : item.sellerId?.name}
                              </p>
                              <p className="text-[9px] text-gray-500 uppercase tracking-widest">{item.sellerId?.department}</p>
+                             </div>
                           </div>
                           {!isOwner && (
                              <Button variant="ghost" className="text-white hover:bg-brand-purple/20 bg-white/5 text-[10px] uppercase font-bold tracking-widest h-8 px-3 transition-colors border border-white/5">Message</Button>

--- a/src/app/dashboard/market/page.tsx
+++ b/src/app/dashboard/market/page.tsx
@@ -25,6 +25,38 @@ function SelectedPhotoPreview({ file }: { file: File }) {
   );
 }
 
+async function refreshAccessToken() {
+  const res = await fetch('/api/auth/refresh', { method: 'POST' });
+  if (!res.ok) return null;
+
+  const data = await res.json();
+  if (typeof data.accessToken !== 'string') return null;
+
+  localStorage.setItem('accessToken', data.accessToken);
+  return data.accessToken;
+}
+
+async function fetchWithAuth(input: RequestInfo | URL, init: RequestInit = {}) {
+  const withToken = (token: string | null): RequestInit => ({
+    ...init,
+    headers: {
+      ...(init.headers || {}),
+      Authorization: `Bearer ${token || ''}`,
+    },
+  });
+
+  let res = await fetch(input, withToken(localStorage.getItem('accessToken')));
+
+  if (res.status === 401) {
+    const nextToken = await refreshAccessToken();
+    if (nextToken) {
+      res = await fetch(input, withToken(nextToken));
+    }
+  }
+
+  return res;
+}
+
 export default function MarketPage() {
   const [items, setItems] = useState<any[]>([]);
   const [title, setTitle] = useState('');
@@ -51,14 +83,16 @@ export default function MarketPage() {
   const handleDelete = async (id: string) => {
      if(!confirm("Are you sure you want to permanently delete this listing?")) return;
      try {
-       const res = await fetch(`/api/market?id=${id}`, {
+       const res = await fetchWithAuth(`/api/market?id=${id}`, {
           method: 'DELETE',
-          headers: { 'Authorization': `Bearer ${localStorage.getItem('accessToken')}` }
        });
        if(res.ok) {
           toast.success("Item permanently removed.");
           fetchItems();
-       } else toast.error("Failed to delete item.");
+       } else {
+          const error = await res.json().catch(() => ({ error: "Failed to delete item." }));
+          toast.error(error.error || "Failed to delete item.");
+       }
      } catch(e) { toast.error("Network error"); }
   };
 
@@ -91,7 +125,7 @@ export default function MarketPage() {
         const uploadRes = await fetch('/api/upload', { method: 'POST', body: formData });
         if (!uploadRes.ok) {
           const error = await uploadRes.json().catch(() => ({ error: 'Image upload failed' }));
-          throw new Error(error.error || 'Image upload failed');
+          throw new Error(error.error || 'Photo upload failed. Try another image or publish without photos.');
         }
         const uploaded = await uploadRes.json();
         if (!uploaded.url) throw new Error('Image upload did not return a URL');
@@ -103,16 +137,19 @@ export default function MarketPage() {
           ? { _id: editingId, title, description, price: Number(price) }
           : { title, description, price: Number(price), imageUrls };
 
-      const res = await fetch('/api/market', {
+      const res = await fetchWithAuth('/api/market', {
          method: method,
-         headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${localStorage.getItem('accessToken')}` },
+         headers: { 'Content-Type': 'application/json' },
          body: JSON.stringify(bodyPayload)
       });
       if(res.ok) {
          toast.success(editingId ? "Listing Modified Successfully!" : "Item successfully listed!");
          cancelEdit();
          fetchItems();
-      } else toast.error("Processing failed.");
+      } else {
+         const error = await res.json().catch(() => ({ error: "Processing failed." }));
+         toast.error(error.error || "Processing failed.");
+      }
     } catch(e) {
       toast.error(e instanceof Error ? e.message : "Network error.");
     } finally { setIsPosting(false); }

--- a/src/app/dashboard/network/page.tsx
+++ b/src/app/dashboard/network/page.tsx
@@ -4,9 +4,10 @@ import React, { useState, useEffect } from 'react';
 import { Card } from '@/components/ui/Card';
 import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
-import { Search, UserPlus, Check, X, Users, Ghost } from 'lucide-react';
+import { Search, UserPlus, Check, Users, Ghost } from 'lucide-react';
 import { motion } from 'framer-motion';
 import toast from 'react-hot-toast';
+import { Avatar } from '@/components/ui/Avatar';
 
 export default function NetworkPage() {
   const [query, setQuery] = useState('');
@@ -104,9 +105,12 @@ export default function NetworkPage() {
                  <h3 className="text-xs font-bold text-brand-accent uppercase tracking-widest pl-2">Search Results</h3>
                  {results.map((user, i) => (
                    <motion.div initial={{opacity:0, y:10}} animate={{opacity:1, y:0}} transition={{delay: i*0.05}} key={user._id} className="flex items-center justify-between p-4 rounded-xl border border-white/5 bg-white/5 hover:bg-white/10 transition-colors">
-                      <div>
-                         <h4 className="font-bold text-white text-lg tracking-tight">{user.name}</h4>
-                         <span className="text-xs text-brand-purple tracking-widest uppercase">{user.department}</span>
+                      <div className="flex min-w-0 items-center gap-3">
+                         <Avatar src={user.profilePicture} name={user.name} className="h-11 w-11 text-base" />
+                         <div className="min-w-0">
+                           <h4 className="truncate font-bold text-white text-lg tracking-tight">{user.name}</h4>
+                           <span className="block truncate text-xs text-brand-purple tracking-widest uppercase">{user.department}</span>
+                         </div>
                       </div>
                       <button onClick={() => sendRequest(user._id)} className="p-3 rounded-lg bg-brand-accent/10 text-brand-accent hover:bg-brand-accent hover:text-black hover:shadow-brand-accent transition-all duration-300">
                          <UserPlus size={20} />
@@ -134,9 +138,7 @@ export default function NetworkPage() {
                     return (
                       <motion.div initial={{opacity:0, scale:0.95}} animate={{opacity:1, scale:1}} transition={{delay: i * 0.1}} key={f._id}>
                         <Card className="p-5 flex gap-4 items-center hover:border-brand-indigo/50 hover:bg-brand-indigo/5 transition-colors cursor-pointer group">
-                           <div className="w-14 h-14 rounded-full gradient-bg flex items-center justify-center text-white font-bold text-2xl uppercase group-hover:shadow-[0_0_20px_rgba(102,126,234,0.4)] transition-all">
-                              {peer.name.charAt(0)}
-                           </div>
+                           <Avatar src={peer.profilePicture} name={peer.name} className="h-14 w-14 text-xl group-hover:shadow-[0_0_20px_rgba(102,126,234,0.4)] transition-all" />
                            <div className="flex flex-col flex-1 truncate">
                               <h4 className="font-bold text-white text-lg leading-tight truncate">{peer.name}</h4>
                               <span className="text-[10px] text-gray-500 font-mono tracking-widest uppercase truncate">{peer.department}</span>
@@ -158,9 +160,12 @@ export default function NetworkPage() {
                  <div className="space-y-4">
                     {pending.map(req => (
                        <div key={req._id} className="p-4 bg-black/40 rounded-xl border border-white/5 shadow-2xl">
-                          <div className="mb-4">
-                             <p className="text-base text-white font-bold truncate">{req.requester.name}</p>
-                             <p className="text-[10px] text-gray-500 font-mono uppercase">{req.requester.department}</p>
+                          <div className="mb-4 flex items-center gap-3">
+                             <Avatar src={req.requester.profilePicture} name={req.requester.name} className="h-10 w-10 text-sm" />
+                             <div className="min-w-0">
+                               <p className="text-base text-white font-bold truncate">{req.requester.name}</p>
+                               <p className="text-[10px] text-gray-500 font-mono uppercase truncate">{req.requester.department}</p>
+                             </div>
                           </div>
                           <div className="flex gap-2">
                              <Button onClick={() => handleAction(req._id, 'accept')} className="flex-1 text-xs py-1 h-9 bg-brand-accent text-black font-bold border-none hover:shadow-brand-accent shadow-md">Accept</Button>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -2,15 +2,17 @@
 
 import React, { useRef, useState, useCallback } from 'react';
 import Link from 'next/link';
-import { User, Bell, Menu, LogOut, Loader2, Camera, Zap } from 'lucide-react';
+import { Bell, Menu, LogOut, Loader2, Camera } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 import toast from 'react-hot-toast';
 import { MobileNav } from './MobileNav';
+import { Avatar } from '@/components/ui/Avatar';
 
 export function Navbar() {
   const router = useRouter();
   const [profilePic, setProfilePic] = useState('');
+  const [profileName, setProfileName] = useState('');
   const [isUploading, setIsUploading] = useState(false);
   const [unreadCount, setUnreadCount] = useState(0);
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
@@ -28,9 +30,11 @@ export function Navbar() {
     try {
       const stored = localStorage.getItem('user');
       if (stored) {
-         setProfilePic(JSON.parse(stored).profilePicture || '');
+         const user = JSON.parse(stored);
+         setProfilePic(user.profilePicture || '');
+         setProfileName(user.name || '');
       }
-    } catch(e) {}
+    } catch {}
 
     // Passive Ping Engine for Dynamic Inbox Tallying
     const fetchUnreads = async (isInitialTrigger = false) => {
@@ -46,7 +50,7 @@ export function Navbar() {
              }
              prevCount.current = data.count;
           }
-       } catch(e) {}
+       } catch {}
     };
 
     fetchUnreads(true);
@@ -103,8 +107,8 @@ export function Navbar() {
          icon: '✨',
          style: { background: 'rgba(0, 245, 255, 0.1)', border: '1px solid rgba(0, 245, 255, 0.2)' }
        });
-     } catch (err: any) {
-       toast.error(err.message || "Failed to upload profile photo");
+     } catch (err: unknown) {
+       toast.error(err instanceof Error ? err.message : "Failed to upload profile photo");
      } finally {
        setIsUploading(false);
        if(fileRef.current) fileRef.current.value = '';
@@ -200,9 +204,9 @@ export function Navbar() {
               {isUploading ? (
                  <Loader2 size={18} className="text-brand-accent animate-spin m-auto" />
               ) : profilePic ? (
-                 <img src={profilePic} alt="Profile" className="w-full h-full object-cover" />
+                 <Avatar src={profilePic} name={profileName} className="h-full w-full border-0 text-sm" />
               ) : (
-                 <User size={18} className="text-white/80 m-auto" />
+                 <Avatar name={profileName} className="h-full w-full border-0 text-sm" />
               )}
             </div>
 

--- a/src/components/ui/Avatar.tsx
+++ b/src/components/ui/Avatar.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import React from "react";
+import { User } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type AvatarProps = {
+  src?: string | null;
+  name?: string | null;
+  className?: string;
+  imageClassName?: string;
+};
+
+export function Avatar({ src, name, className, imageClassName }: AvatarProps) {
+  const [failed, setFailed] = React.useState(false);
+  const initials = (name || "U")
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((part) => part.charAt(0))
+    .join("")
+    .toUpperCase();
+
+  React.useEffect(() => {
+    setFailed(false);
+  }, [src]);
+
+  return (
+    <div
+      className={cn(
+        "relative flex shrink-0 items-center justify-center overflow-hidden rounded-full border border-white/15 bg-gradient-to-br from-cyan-400/25 via-emerald-300/15 to-white/10 text-white shadow-inner shadow-white/10",
+        className
+      )}
+      title={name || "Profile"}
+    >
+      {src && !failed ? (
+        <img
+          src={src}
+          alt={name ? `${name}'s profile picture` : "Profile picture"}
+          className={cn("h-full w-full object-cover", imageClassName)}
+          onError={() => setFailed(true)}
+        />
+      ) : initials ? (
+        <span className="text-[0.7em] font-black leading-none tracking-normal">
+          {initials}
+        </span>
+      ) : (
+        <User size="55%" className="text-white/75" />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Fix profile picture saves by reading the same JWT user id shape used by login tokens.
- Add a reusable Avatar component with image fallback initials.
- Show profile pictures in network search, friends, chat, marketplace owners, and lost/found reporters.
- Make Market and Lost & Found image uploads fail loudly instead of publishing blank-image posts.
- Keep Gemini AI provider dependency and route fallback included in the branch.

## Validation
- Ran `npx tsc --noEmit` successfully in the working app.
- Ran `npm run build` successfully in the working app.
- Verified local dev server responds with `/login` returning 200.

## Notes
- No `.env.local` or secret values were staged or committed.